### PR TITLE
Fixed normals for M2 and WMO

### DIFF
--- a/WoWExportTools/Exporters/OBJ/ADTExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/ADTExporter.cs
@@ -73,8 +73,8 @@ namespace OBJExporterUI.Exporters.OBJ
             var adtStartY = ((reader.adtfile.y - 32) * TileSize) * -1;
 
             // Calculate first chunk offset in world coordinates
-            var initialChunkX = adtStartY + (reader.adtfile.chunks[0].header.indexX * ChunkSize) * -1;
-            var initialChunkY = adtStartX + (reader.adtfile.chunks[0].header.indexY * ChunkSize) * -1;
+            var initialChunkX = adtStartX + (reader.adtfile.chunks[0].header.indexX * ChunkSize) * -1;
+            var initialChunkY = adtStartY + (reader.adtfile.chunks[0].header.indexY * ChunkSize) * -1;
 
             uint ci = 0;
             for (var x = 0; x < 16; x++)

--- a/WoWExportTools/Exporters/OBJ/M2Exporter.cs
+++ b/WoWExportTools/Exporters/OBJ/M2Exporter.cs
@@ -126,9 +126,14 @@ namespace OBJExporterUI.Exporters.OBJ
 
             foreach (var vertex in vertices)
             {
+                /*
                 objsw.WriteLine("v " + vertex.Position.X + " " + vertex.Position.Y + " " + vertex.Position.Z);
                 objsw.WriteLine("vt " + vertex.TexCoord.X + " " + -vertex.TexCoord.Y);
                 objsw.WriteLine("vn " + vertex.Normal.X.ToString("F12") + " " + vertex.Normal.Y.ToString("F12") + " " + vertex.Normal.Z.ToString("F12"));
+                */
+                objsw.WriteLine("v " + -vertex.Position.X + " " + vertex.Position.Y + " " + -vertex.Position.Z);
+                objsw.WriteLine("vt " + vertex.TexCoord.X + " " + (vertex.TexCoord.Y -1)*-1); //the last part is centering the UV
+                objsw.WriteLine("vn " + (-vertex.Normal.X).ToString("F12") + " " + vertex.Normal.Y.ToString("F12") + " " + vertex.Normal.Z.ToString("F12"));
             }
 
             var indicelist = new List<uint>();

--- a/WoWExportTools/Exporters/OBJ/WMOExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/WMOExporter.cs
@@ -496,9 +496,14 @@ namespace OBJExporterUI.Exporters.OBJ
 
                 foreach (var vertex in group.vertices)
                 {
+                    /*
                     objsw.WriteLine("v " + vertex.Position.X + " " + vertex.Position.Y + " " + vertex.Position.Z);
                     objsw.WriteLine("vt " + vertex.TexCoord.X + " " + -vertex.TexCoord.Y);
                     objsw.WriteLine("vn " + vertex.Normal.X.ToString("F12") + " " + vertex.Normal.Y.ToString("F12") + " " + vertex.Normal.Z.ToString("F12"));
+                    */
+                    objsw.WriteLine("v " + vertex.Position.X + " " + vertex.Position.Y + " " + vertex.Position.Z);
+                    objsw.WriteLine("vt " + vertex.TexCoord.X + " " + (vertex.TexCoord.Y - 1) * -1); //the last part is centering the UV
+                    objsw.WriteLine("vn " + (-vertex.Normal.X).ToString("F12") + " " + vertex.Normal.Y.ToString("F12") + " " + vertex.Normal.Z.ToString("F12"));
                 }
 
                 var indices = group.indices;


### PR DESCRIPTION
-Fixed normals for both M2 and WMO exporters
-Fixed the X/Y being swapped at the calculation of the fist chunk in ADT expoter