### PR TITLE
Remove tile existence checks, resolves #45

### DIFF
--- a/WoWExportTools/Renderer/RenderMinimap.cs
+++ b/WoWExportTools/Renderer/RenderMinimap.cs
@@ -46,11 +46,6 @@ namespace WoWExportTools.Renderer
                 Directory.CreateDirectory(Path.GetDirectoryName(outName));
             }
 
-            if (!splitFiles && File.Exists(outName))
-            {
-                return;
-            }
-
             // Force terrain cache to empty after having 1 ADT cached and run GC
             if(cache.terrain.Count > 1)
             {
@@ -110,11 +105,6 @@ namespace WoWExportTools.Renderer
 
                 for (var i = 0; i < cachedFile.renderBatches.Length; i++)
                 {
-                    if(File.Exists(outName.Replace(".png", "_" + i + ".png")))
-                    {
-                        continue;
-                    }
-
                     var x = i / 16;
                     var y = i % 16;
 
@@ -216,11 +206,6 @@ namespace WoWExportTools.Renderer
             }
             else
             {
-                if (File.Exists(outName))
-                {
-                    return;
-                }
-
                 var frameBuffer = GL.GenFramebuffer();
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBuffer);
 


### PR DESCRIPTION
The ADT exporter checks for baked tiles on disk and skips baking if the file already exists. Since all baking resolutions (aside from 16k) use the same naming convention, this causes some conflict (see #45).

This PR removes the checks and requires that tiles are always baked, even if the files already exist. This ensures that switching from one render resolution to another doesn't fail to produce the correct texture. It also means users no longer need to clear out the textures from their output directory to re-bake something if it has changed.

One of these file checks was entirely redundant and never reached anyway.