### PR TITLE
Implement direct M2 conversion, resolves #46

### DIFF
--- a/WoWExportTools/MainWindow.xaml
+++ b/WoWExportTools/MainWindow.xaml
@@ -27,6 +27,7 @@
                 <MenuItem Header="Tools">
                     <MenuItem Name="MenuListfile" Header="Update Listfile" Click="MenuListfile_Click" IsEnabled="False"></MenuItem>
                     <MenuItem Name="MenuMapNames" Header="Update Map list" Click="MenuMapNames_Click" IsEnabled="True"></MenuItem>
+                    <MenuItem Name="MenuConvertM2" Header="Convert local M2 to OBJ" Click="MenuConvertM2_Click" IsEnabled="True"></MenuItem>
                 </MenuItem>
                 <MenuItem Header="About">
                     <MenuItem Name="MenuVersion" Header="Version" Click="MenuVersion_Click"></MenuItem>

--- a/WoWExportTools/MainWindow.xaml
+++ b/WoWExportTools/MainWindow.xaml
@@ -28,6 +28,7 @@
                     <MenuItem Name="MenuListfile" Header="Update Listfile" Click="MenuListfile_Click" IsEnabled="False"></MenuItem>
                     <MenuItem Name="MenuMapNames" Header="Update Map list" Click="MenuMapNames_Click" IsEnabled="True"></MenuItem>
                     <MenuItem Name="MenuConvertM2" Header="Convert local M2 to OBJ" Click="MenuConvertM2_Click" IsEnabled="True"></MenuItem>
+                    <MenuItem Name="MenuConvertBLP" Header="Convert local BLP to PNG" Click="MenuConvertBLP_Click" IsEnabled="True"></MenuItem>
                 </MenuItem>
                 <MenuItem Header="About">
                     <MenuItem Name="MenuVersion" Header="Version" Click="MenuVersion_Click"></MenuItem>

--- a/WoWExportTools/MainWindow.xaml.cs
+++ b/WoWExportTools/MainWindow.xaml.cs
@@ -53,7 +53,8 @@ namespace WoWExportTools
 
         public static bool shuttingDown = false;
 
-        private System.Windows.Forms.OpenFileDialog dialogOpen;
+        private System.Windows.Forms.OpenFileDialog dialogM2Open;
+        private System.Windows.Forms.OpenFileDialog dialogBLPOpen;
 
         public MainWindow(Splash splash)
         {
@@ -110,11 +111,18 @@ namespace WoWExportTools
             exportFoliage.IsChecked = ConfigurationManager.AppSettings["exportFoliage"] == "True";
 
             // Set-up conversion dialogs.
-            dialogOpen = new System.Windows.Forms.OpenFileDialog()
+            dialogM2Open = new System.Windows.Forms.OpenFileDialog()
             {
                 FileName = "Select an M2 file",
                 Filter = "M2 Files (*.m2)|*.m2",
                 Title = "Open M2 File"
+            };
+
+            dialogBLPOpen = new System.Windows.Forms.OpenFileDialog()
+            {
+                FileName = "Select a BLP file",
+                Filter = "BLP Files (*.blp)|*.blp",
+                Title = "Open BLP File"
             };
         }
 
@@ -1325,12 +1333,12 @@ namespace WoWExportTools
 
         private void MenuConvertM2_Click(object sender, RoutedEventArgs e)
         {
-            if (dialogOpen.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            if (dialogM2Open.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 try
                 {
-                    var filePath = dialogOpen.FileName;
-                    using (Stream dataStream = dialogOpen.OpenFile())
+                    var filePath = dialogM2Open.FileName;
+                    using (Stream dataStream = dialogM2Open.OpenFile())
                     {
                         var reader = new M2Reader();
                         reader.LoadM2(dataStream);
@@ -1341,6 +1349,32 @@ namespace WoWExportTools
                 catch (Exception ex)
                 {
                     Console.WriteLine("Exception reading local M2: " + ex.Message);
+                }
+            }
+        }
+
+        private void MenuConvertBLP_Click(object sender, RoutedEventArgs e)
+        {
+            if (dialogBLPOpen.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                try
+                {
+                    var filePath = dialogBLPOpen.FileName;
+                    using (Stream dataStream = dialogBLPOpen.OpenFile())
+                    {
+                        BLPReader reader = new BLPReader();
+                        reader.LoadBLP(dataStream);
+
+                        Bitmap bmp = reader.bmp;
+                        if (ignoreTextureAlpha)
+                            bmp = bmp.Clone(new Rectangle(0, 0, bmp.Width, bmp.Height), System.Drawing.Imaging.PixelFormat.Format32bppRgb);
+
+                        bmp.Save(Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + ".png"));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Exception reading local BLP: " + ex.Message);
                 }
             }
         }

--- a/WoWExportTools/MainWindow.xaml.cs
+++ b/WoWExportTools/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using WoWFormatLib.Utils;
+using WoWFormatLib.FileReaders;
 
 namespace WoWExportTools
 {
@@ -51,6 +52,8 @@ namespace WoWExportTools
         private Splash splash;
 
         public static bool shuttingDown = false;
+
+        private System.Windows.Forms.OpenFileDialog dialogOpen;
 
         public MainWindow(Splash splash)
         {
@@ -105,6 +108,14 @@ namespace WoWExportTools
             exportWMO.IsChecked = ConfigurationManager.AppSettings["exportWMO"] == "True";
             exportM2.IsChecked = ConfigurationManager.AppSettings["exportM2"] == "True";
             exportFoliage.IsChecked = ConfigurationManager.AppSettings["exportFoliage"] == "True";
+
+            // Set-up conversion dialogs.
+            dialogOpen = new System.Windows.Forms.OpenFileDialog()
+            {
+                FileName = "Select an M2 file",
+                Filter = "M2 Files (*.m2)|*.m2",
+                Title = "Open M2 File"
+            };
         }
 
         private void Adtexporterworker_DoWork(object sender, DoWorkEventArgs e)
@@ -1310,6 +1321,28 @@ namespace WoWExportTools
             config.Save(ConfigurationSaveMode.Full);
 
             e.Handled = true;
+        }
+
+        private void MenuConvertM2_Click(object sender, RoutedEventArgs e)
+        {
+            if (dialogOpen.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                try
+                {
+                    var filePath = dialogOpen.FileName;
+                    using (Stream dataStream = dialogOpen.OpenFile())
+                    {
+                        var reader = new M2Reader();
+                        reader.LoadM2(dataStream);
+
+                        Exporters.OBJ.M2Exporter.ExportM2(reader, filePath, null, Path.GetDirectoryName(filePath), true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Exception reading local M2: " + ex.Message);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR implements a tool (located in the Tools menu drop-down) that allows the user to specify a local M2 which will be converted to an OBJ in-place.

In addition, it contains some code quality improvements as well as a few minor bug-fixes to the M2 exporter.