### PR TITLE
Add toggle for object collision exporting

### DIFF
--- a/WoWExportTools/App.config
+++ b/WoWExportTools/App.config
@@ -15,6 +15,7 @@
     <add key="exportWMO" value="True" />
     <add key="exportM2" value="True" />
     <add key="exportFoliage" value="True" />
+    <add key="exportCollision" value="False" />
     <add key="bakeQuality" value="low" />
     <add key="textureMetadata" value="False" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />

--- a/WoWExportTools/Exporters/OBJ/M2Exporter.cs
+++ b/WoWExportTools/Exporters/OBJ/M2Exporter.cs
@@ -226,7 +226,7 @@ namespace WoWExportTools.Exporters.OBJ
             objWriter.Close();
 
             // Only export phys when exporting a single M2, causes issues for some users when combined with WMO/ADT
-            if (destinationOverride == null)
+            if (destinationOverride == null && ConfigurationManager.AppSettings["exportCollision"] == "True")
             {
                 exportworker.ReportProgress(90, "Exporting collision..");
 

--- a/WoWExportTools/MainWindow.xaml
+++ b/WoWExportTools/MainWindow.xaml
@@ -42,12 +42,13 @@
         <Image Grid.Column="0" x:Name="loadingImage" Source="Resources/icon.png" Margin="0,0,0,0" Width="100" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <TextBox Grid.Column="0" x:Name="filterTextBox" Visibility="Hidden" HorizontalAlignment="Stretch" Height="23" Margin="234,55,0,0" TextWrapping="Wrap" ToolTip="Type something here to filter.." VerticalAlignment="Top" TextChanged="FilterBox_TextChanged" Panel.ZIndex="2"/>
         <Label Grid.Column="0" Content="Filter" Name="filterTextLabel" Visibility="Hidden" HorizontalAlignment="Stretch" Margin="198,55,366,0" VerticalAlignment="Top" Height="23" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Center"/>
-        <TabControl SelectionChanged="TabControl_SelectionChanged" Grid.Column="0" x:Name="tabs" Margin="0,60,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Width="Auto" Height="Auto" Visibility="Hidden" KeyboardNavigation.DirectionalNavigation="None">
+        <TabControl SelectionChanged="TabControl_SelectionChanged" Grid.Column="0" x:Name="tabs" Margin="0,60,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Width="Auto" Height="Auto" Visibility="Visible" KeyboardNavigation.DirectionalNavigation="None">
             <TabItem x:Name="ModelsTab" Header="Models">
                 <Grid>
                     <CheckBox Checked="ModelCheckBoxChanged" Unchecked="ModelCheckBoxChanged" IsChecked="True" x:Name="wmoCheckBox" Content="WMOs" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
                     <CheckBox Checked="ModelCheckBoxChanged" Unchecked="ModelCheckBoxChanged" IsChecked="True" x:Name="m2CheckBox" Content="M2s" HorizontalAlignment="Left" Margin="71,10,0,0" VerticalAlignment="Top"/>
                     <CheckBox Checked="PreviewCheckbox_Checked" Unchecked="PreviewCheckbox_Checked" IsChecked="True" x:Name="previewCheckbox" Content="Enable preview" HorizontalAlignment="Left" Margin="485,10,0,0" VerticalAlignment="Top"/>
+                    <CheckBox Checked="CollisionCheckbox_Checked" Unchecked="CollisionCheckbox_Checked" IsChecked="False" x:Name="exportCollision" Content="Export Collision" HorizontalAlignment="Left" Margin="368,10,0,0" VerticalAlignment="Top" Width="112"/>
                     <ListBox x:Name="modelListBox" SelectionMode="Extended" SelectionChanged="ModelListBox_SelectionChanged" HorizontalAlignment="Stretch" Margin="10,30,10,40" VerticalAlignment="Stretch" ItemsSource="{Binding}"></ListBox>
                     <Button x:Name="exportButton" Height="25" Content="Export model to OBJ!" HorizontalAlignment="Stretch" Margin="10,0,10.4,10" VerticalAlignment="Bottom" Click="ExportButton_Click"/>
                 </Grid>

--- a/WoWExportTools/MainWindow.xaml.cs
+++ b/WoWExportTools/MainWindow.xaml.cs
@@ -106,6 +106,7 @@ namespace WoWExportTools
             exportWMO.IsChecked = ConfigurationManager.AppSettings["exportWMO"] == "True";
             exportM2.IsChecked = ConfigurationManager.AppSettings["exportM2"] == "True";
             exportFoliage.IsChecked = ConfigurationManager.AppSettings["exportFoliage"] == "True";
+            exportCollision.IsChecked = ConfigurationManager.AppSettings["exportCollision"] == "True";
 
             // Set-up conversion dialogs.
             dialogM2Open = new System.Windows.Forms.OpenFileDialog()
@@ -248,6 +249,7 @@ namespace WoWExportTools
                 m2CheckBox.IsEnabled = false;
                 exportButton.IsEnabled = false;
                 modelListBox.IsEnabled = false;
+                exportCollision.IsEnabled = false;
 
                 exportworker.RunWorkerAsync(modelListBox.SelectedItems);
             }
@@ -367,6 +369,7 @@ namespace WoWExportTools
             exportButton.Visibility = Visibility.Visible;
             wmoCheckBox.Visibility = Visibility.Visible;
             m2CheckBox.Visibility = Visibility.Visible;
+            exportCollision.Visibility = Visibility.Visible;
 
             splash.Visibility = Visibility.Hidden;
             Visibility = Visibility.Collapsed;
@@ -540,6 +543,7 @@ namespace WoWExportTools
             wmoCheckBox.IsEnabled = true;
             m2CheckBox.IsEnabled = true;
             modelListBox.IsEnabled = true;
+            exportCollision.IsEnabled = true;
 
             /* ADT specific UI */
             exportTileButton.IsEnabled = true;
@@ -657,8 +661,8 @@ namespace WoWExportTools
             if (exportButton == null) { return; }
             if (m2CheckBox == null) { return; }
 
-            if ((bool)m2CheckBox.IsChecked) { showM2 = true; } else { showM2 = false; }
-            if ((bool)wmoCheckBox.IsChecked) { showWMO = true; } else { showWMO = false; }
+            showM2 = (bool)m2CheckBox.IsChecked;
+            showWMO = (bool)wmoCheckBox.IsChecked;
 
             progressBar.Visibility = Visibility.Visible;
             loadingLabel.Visibility = Visibility.Visible;
@@ -668,6 +672,7 @@ namespace WoWExportTools
             filterTextLabel.Visibility = Visibility.Hidden;
             wmoCheckBox.Visibility = Visibility.Hidden;
             m2CheckBox.Visibility = Visibility.Hidden;
+            exportCollision.Visibility = Visibility.Hidden;
 
             models = new List<string>();
             textures = new List<string>();
@@ -1251,33 +1256,36 @@ namespace WoWExportTools
             previewsEnabled = (bool)previewCheckbox.IsChecked;
         }
 
+        private void CollisionCheckbox_Checked(object sender, RoutedEventArgs e)
+        {
+            SetConfigValue("exportCollision", exportCollision.IsChecked.ToString());
+        }
+
         private void ExportWMO_Click(object sender, RoutedEventArgs e)
         {
-            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
-            config.AppSettings.Settings["exportWMO"].Value = exportWMO.IsChecked.ToString();
-            config.Save(ConfigurationSaveMode.Full);
+            SetConfigValue("exportWMO", exportWMO.IsChecked.ToString());
         }
         private void ExportM2_Click(object sender, RoutedEventArgs e)
         {
-            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
-            config.AppSettings.Settings["exportM2"].Value = exportM2.IsChecked.ToString();
-            config.Save(ConfigurationSaveMode.Full);
+            SetConfigValue("exportM2", exportM2.IsChecked.ToString());
         }
 
         private void ExportFoliage_Click(object sender, RoutedEventArgs e)
         {
-            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
-            config.AppSettings.Settings["exportFoliage"].Value = exportFoliage.IsChecked.ToString();
-            config.Save(ConfigurationSaveMode.Full);
+            SetConfigValue("exportFoliage", exportFoliage.IsChecked.ToString());
         }
 
         private void BakeSize_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
-            config.AppSettings.Settings["bakeQuality"].Value = ((ComboBoxItem)bakeSize.SelectedItem).Name;
-            config.Save(ConfigurationSaveMode.Full);
-
+            SetConfigValue("bakeQuality", ((ComboBoxItem)bakeSize.SelectedItem).Name);
             e.Handled = true;
+        }
+
+        private void SetConfigValue(string key, string value)
+        {
+            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            config.AppSettings.Settings[key].Value = value;
+            config.Save(ConfigurationSaveMode.Full);
         }
 
         private void MenuConvertM2_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This PR makes the following changes:
- Adds a toggle box above the model import frame allowing users to disable the exporting of collision (.phys.obj) data. This setting is persisted in the user configuration and as per our Discord discussion is disabled by default.
- A handful of refactoring in the MainWindow class to reduce duplicate code.
- The main tab control is now visible by default for debugging purposes since it is normally not seen behind the splash window.