### PR TITLE
Enables CTRL+C to copy filenames from list boxes, resolves #35

### DIFF
--- a/WoWExportTools/MainWindow.xaml
+++ b/WoWExportTools/MainWindow.xaml
@@ -49,7 +49,7 @@
                     <CheckBox Checked="ModelCheckBoxChanged" Unchecked="ModelCheckBoxChanged" IsChecked="True" x:Name="m2CheckBox" Content="M2s" HorizontalAlignment="Left" Margin="71,10,0,0" VerticalAlignment="Top"/>
                     <CheckBox Checked="PreviewCheckbox_Checked" Unchecked="PreviewCheckbox_Checked" IsChecked="True" x:Name="previewCheckbox" Content="Enable preview" HorizontalAlignment="Left" Margin="485,10,0,0" VerticalAlignment="Top"/>
                     <CheckBox Checked="CollisionCheckbox_Checked" Unchecked="CollisionCheckbox_Checked" IsChecked="False" x:Name="exportCollision" Content="Export Collision" HorizontalAlignment="Left" Margin="368,10,0,0" VerticalAlignment="Top" Width="112"/>
-                    <ListBox x:Name="modelListBox" SelectionMode="Extended" SelectionChanged="ModelListBox_SelectionChanged" HorizontalAlignment="Stretch" Margin="10,30,10,40" VerticalAlignment="Stretch" ItemsSource="{Binding}"></ListBox>
+                    <ListBox x:Name="modelListBox" SelectionMode="Extended" SelectionChanged="ModelListBox_SelectionChanged" HorizontalAlignment="Stretch" Margin="10,30,10,40" VerticalAlignment="Stretch" ItemsSource="{Binding}" KeyDown="ListBoxKeyDown"></ListBox>
                     <Button x:Name="exportButton" Height="25" Content="Export model to OBJ!" HorizontalAlignment="Stretch" Margin="10,0,10.4,10" VerticalAlignment="Bottom" Click="ExportButton_Click"/>
                 </Grid>
             </TabItem>
@@ -59,7 +59,7 @@
                         <RowDefinition Height="2*"/>
                         <RowDefinition Height="2*" />
                     </Grid.RowDefinitions>
-                    <ListBox Grid.Row="0" x:Name="textureListBox" SelectionMode="Extended" SelectionChanged="TextureListBox_SelectionChanged" HorizontalAlignment="Stretch" Margin="10" VerticalAlignment="Stretch" ItemsSource="{Binding}"></ListBox>
+                    <ListBox Grid.Row="0" x:Name="textureListBox" SelectionMode="Extended" SelectionChanged="TextureListBox_SelectionChanged" HorizontalAlignment="Stretch" Margin="10" VerticalAlignment="Stretch" ItemsSource="{Binding}" KeyDown="ListBoxKeyDown"></ListBox>
                     <CheckBox Content="Ignore transparency" Unchecked="IgnoreAlpha_Checked" Checked="IgnoreAlpha_Checked" Panel.ZIndex="2" x:Name="ignoreAlpha" HorizontalAlignment="Left" Margin="10,0,0,40" Foreground="Black" VerticalAlignment="Bottom" IsChecked="False" Width="140" Grid.Row="1"/>
                     <Border Grid.Row="1" BorderBrush="White" BorderThickness="1" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10,0,10,40">
                         <Border.Background>

--- a/WoWExportTools/MainWindow.xaml.cs
+++ b/WoWExportTools/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Input;
 using WoWFormatLib.FileReaders;
 using WoWFormatLib.Utils;
 
@@ -1333,6 +1334,23 @@ namespace WoWExportTools
                 catch (Exception ex)
                 {
                     Console.WriteLine("Exception reading local BLP: " + ex.Message);
+                }
+            }
+        }
+
+        private void ListBoxKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C)
+            {
+                ListBox box = (ListBox)sender;
+
+                if (box.SelectedItems.Count > 0)
+                {
+                    List<string> items = new List<string>(box.SelectedItems.Count);
+                    foreach (string item in box.SelectedItems)
+                        items.Add(item);
+
+                    Clipboard.SetText(string.Join("\n", items));
                 }
             }
         }


### PR DESCRIPTION
As per the issue, this PR implements the ability to copy selected filenames from the model and texture file lists onto the clipboard using the CTRL+C keyboard shortcut.

If multiple files are selected, they will all be copied, separated by a single newline character (\n).

**Example output:**
```
character/goblin/female/goblinfemale.m2
```

**Example for multi-selection:**
```
character/gnome/male/gnomemale_hd_sdr.m2
character/goblin/female/goblinfemale.m2
character/goblin/female/goblinfemale_sdr.m2
character/goblin/male/goblinmale.m2
character/goblin/male/goblinmale_sdr.m2
character/highmountaintauren/female/highmountaintaurenfemale.m2
character/highmountaintauren/female/highmountaintaurenfemale_sdr.m2
```