### PR TITLE
Focus the model control window if it is already active

### DIFF
--- a/WoWExportTools/MainWindow.xaml.cs
+++ b/WoWExportTools/MainWindow.xaml.cs
@@ -1360,6 +1360,7 @@ namespace WoWExportTools
         private void ShowModelControlButton_Click(object sender, RoutedEventArgs e)
         {
             modelControlWindow.Show();
+            modelControlWindow.Focus();
         }
 
         private void Window_Closing(object sender, CancelEventArgs e)


### PR DESCRIPTION
This PR introduces a small bug fix to ensure the model control window is brought into focus if it has already been created but is currently out of focus when the user selects the 'Model Control' button.