### PR TITLE
Improve MDX support

### DIFF
--- a/WoWExportTools/Exporters/OBJ/MDXExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/MDXExporter.cs
@@ -25,7 +25,7 @@ namespace WoWExportTools.Exporters.OBJ
             MDXModel model = reader.model;
 
             // Empty model.
-            if (model.geosets != null)
+            if (model.geosets == null)
                 return;
 
             worker.ReportProgress(60, "Writing material library...");

--- a/WoWExportTools/Exporters/OBJ/MDXExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/MDXExporter.cs
@@ -37,7 +37,7 @@ namespace WoWExportTools.Exporters.OBJ
             {
                 Geoset geoset = model.geosets[geosetIndex];
                 for (int i = 0; i < geoset.verts.Length; i++)
-                    writer.WriteLine("v {0} {1} {2}", geoset.verts[i].x, geoset.verts[i].z, geoset.verts[i].y);
+                    writer.WriteLine("v {0} {1} {2}", geoset.verts[i].x, geoset.verts[i].z, -geoset.verts[i].y);
             }
 
             writer.WriteLine("\n# Normals");

--- a/WoWExportTools/Exporters/OBJ/MDXExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/MDXExporter.cs
@@ -24,6 +24,10 @@ namespace WoWExportTools.Exporters.OBJ
             worker.ReportProgress(30, "Reading MDX file...");
             MDXModel model = reader.model;
 
+            // Empty model.
+            if (model.geosets != null)
+                return;
+
             worker.ReportProgress(60, "Writing material library...");
             // Write the material library.
 

--- a/WoWExportTools/Exporters/OBJ/MDXExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/MDXExporter.cs
@@ -18,42 +18,62 @@ namespace WoWExportTools.Exporters.OBJ
             customCulture.NumberFormat.NumberDecimalSeparator = ".";
             Thread.CurrentThread.CurrentCulture = customCulture;
 
-            worker.ReportProgress(15, "Reading MDX file...");
+            string mtlFile = Path.GetFileNameWithoutExtension(outFile) + ".mtl";
+            string mtlPath = Path.Combine(Path.GetDirectoryName(outFile), mtlFile);
+
+            worker.ReportProgress(30, "Reading MDX file...");
             MDXModel model = reader.model;
 
-            StreamWriter writer = new StreamWriter(outFile);
+            worker.ReportProgress(60, "Writing material library...");
+            // Write the material library.
+            StreamWriter writerMTL = new StreamWriter(mtlPath);
+            for (int i = 0; i < model.textures.Length; i++)
+            {
+                string rawFile = Path.GetFileNameWithoutExtension(model.textures[i]);
+                writerMTL.WriteLine("newmtl {0}", rawFile);
+                writerMTL.WriteLine("illum 1");
+                writerMTL.WriteLine("map_Kd {0}.dds\n", rawFile);
+            }
 
-            writer.WriteLine("# Exported using Marlamin's WoW Export Tools. MDX Exporter by Kruithne.");
-            writer.WriteLine("# Model: {0} (MDX version {1})\n", model.name, model.version);
+            writerMTL.Close();
+
+
+            worker.ReportProgress(90, "Writing OBJ...");
+            StreamWriter writerOBJ = new StreamWriter(outFile);
+
+            writerOBJ.WriteLine("# Exported using Marlamin's WoW Export Tools. MDX Exporter by Kruithne.");
+            writerOBJ.WriteLine("# Model: {0} (MDX version {1})\n", model.name, model.version);
+
+            writerOBJ.WriteLine("mtllib {0}\n", mtlFile);
 
             // Object Name
-            writer.WriteLine("o {0}", model.name);
+            writerOBJ.WriteLine("o {0}", model.name);
 
             // Instead of writing verts/normals/uvs for each geoset in order, we instead
             // batch all of them together in three large lists at the top.
 
-            writer.WriteLine("\n# Verticies");
+            writerOBJ.WriteLine("\n# Verticies");
             for (int geosetIndex = 0; geosetIndex < model.geosets.Length; geosetIndex++)
             {
                 Geoset geoset = model.geosets[geosetIndex];
                 for (int i = 0; i < geoset.verts.Length; i++)
-                    writer.WriteLine("v {0} {1} {2}", geoset.verts[i].x, geoset.verts[i].z, -geoset.verts[i].y);
+                    writerOBJ.WriteLine("v {0} {1} {2}", geoset.verts[i].x, geoset.verts[i].z, -geoset.verts[i].y);
             }
 
-            writer.WriteLine("\n# Normals");
+            writerOBJ.WriteLine("\n# Normals");
             for (int geosetIndex = 0; geosetIndex < model.geosets.Length; geosetIndex++)
             {
                 Geoset geoset = model.geosets[geosetIndex];
                 for(int i = 0; i < geoset.normals.Length; i++)
-                    writer.WriteLine("vn {0} {1} {2}", geoset.normals[i].x, geoset.normals[i].y, geoset.normals[i].z);
+                    writerOBJ.WriteLine("vn {0} {1} {2}", geoset.normals[i].x, geoset.normals[i].y, geoset.normals[i].z);
             }
 
-            writer.WriteLine("\n# UVs");
+            writerOBJ.WriteLine("\n# UVs");
             for (int geosetIndex = 0; geosetIndex < model.geosets.Length; geosetIndex++)
             {
                 Geoset geoset = model.geosets[geosetIndex];
                 for (int i = 0; i < geoset.uvs.Length; i++)
-                    writer.WriteLine("vt {0} {1}", geoset.uvs[i].x, geoset.uvs[i].y * -1); // Flip the Y UV, because it's backwards?
+                    writerOBJ.WriteLine("vt {0} {1}", geoset.uvs[i].x, geoset.uvs[i].y * -1); // Flip the Y UV, because it's backwards?
             }
 
             // Write geoset meshes together.
@@ -61,17 +81,21 @@ namespace WoWExportTools.Exporters.OBJ
             for (int geosetIndex = 0; geosetIndex < model.geosets.Length; geosetIndex++)
             {
                 Geoset geoset = model.geosets[geosetIndex];
-                writer.WriteLine("\ng {0}", geoset.name);
+                writerOBJ.WriteLine("\ng {0}", geoset.name);
+
+                string textureFile = model.textures[model.materials[geoset.materialIndex].textureID];
+                writerOBJ.WriteLine("usemtl {0}", Path.GetFileNameWithoutExtension(textureFile));
+                writerOBJ.WriteLine("s 1");
 
                 // +1 to each face to account for OBJ not liking zero-indexed lists.
                 for (int i = 0; i < geoset.primitives.Length; i++)
-                    writer.WriteLine("f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}", faceIndex + geoset.primitives[i].v1 + 1, faceIndex + geoset.primitives[i].v2 + 1, faceIndex + geoset.primitives[i].v3 + 1);
+                    writerOBJ.WriteLine("f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}", faceIndex + geoset.primitives[i].v1 + 1, faceIndex + geoset.primitives[i].v2 + 1, faceIndex + geoset.primitives[i].v3 + 1);
 
                 // Maintain absolute offset rather than relative.
                 faceIndex += geoset.verts.Length;
             }
 
-            writer.Close();
+            writerOBJ.Close();
         }
     }
 }

--- a/WoWExportTools/Exporters/OBJ/MDXExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/MDXExporter.cs
@@ -26,17 +26,20 @@ namespace WoWExportTools.Exporters.OBJ
 
             worker.ReportProgress(60, "Writing material library...");
             // Write the material library.
-            StreamWriter writerMTL = new StreamWriter(mtlPath);
-            for (int i = 0; i < model.textures.Length; i++)
+
+            if (model.textures != null)
             {
-                string rawFile = Path.GetFileNameWithoutExtension(model.textures[i]);
-                writerMTL.WriteLine("newmtl {0}", rawFile);
-                writerMTL.WriteLine("illum 1");
-                writerMTL.WriteLine("map_Kd {0}.dds\n", rawFile);
+                StreamWriter writerMTL = new StreamWriter(mtlPath);
+                for (int i = 0; i < model.textures.Length; i++)
+                {
+                    string rawFile = Path.GetFileNameWithoutExtension(model.textures[i]);
+                    writerMTL.WriteLine("newmtl {0}", rawFile);
+                    writerMTL.WriteLine("illum 1");
+                    writerMTL.WriteLine("map_Kd {0}.dds\n", rawFile);
+                }
+
+                writerMTL.Close();
             }
-
-            writerMTL.Close();
-
 
             worker.ReportProgress(90, "Writing OBJ...");
             StreamWriter writerOBJ = new StreamWriter(outFile);
@@ -83,9 +86,12 @@ namespace WoWExportTools.Exporters.OBJ
                 Geoset geoset = model.geosets[geosetIndex];
                 writerOBJ.WriteLine("\ng {0}", geoset.name);
 
-                string textureFile = model.textures[model.materials[geoset.materialIndex].textureID];
-                writerOBJ.WriteLine("usemtl {0}", Path.GetFileNameWithoutExtension(textureFile));
-                writerOBJ.WriteLine("s 1");
+                if (model.textures != null)
+                {
+                    string textureFile = model.textures[model.materials[geoset.materialIndex].textureID];
+                    writerOBJ.WriteLine("usemtl {0}", Path.GetFileNameWithoutExtension(textureFile));
+                    writerOBJ.WriteLine("s 1");
+                }
 
                 // +1 to each face to account for OBJ not liking zero-indexed lists.
                 for (int i = 0; i < geoset.primitives.Length; i++)

--- a/WoWExportTools/MainWindow.xaml.cs
+++ b/WoWExportTools/MainWindow.xaml.cs
@@ -132,14 +132,16 @@ namespace WoWExportTools
             {
                 FileName = "Select an M2/MDX file",
                 Filter = "Warcraft Model File (*.m2, *.mdx)|*.m2;*.mdx",
-                Title = "Open M2/MDX File"
+                Title = "Open M2/MDX File",
+                Multiselect = true
             };
 
             dialogBLPOpen = new System.Windows.Forms.OpenFileDialog()
             {
                 FileName = "Select a BLP file",
                 Filter = "BLP Files (*.blp)|*.blp",
-                Title = "Open BLP File"
+                Title = "Open BLP File",
+                Multiselect = true
             };
         }
 
@@ -1431,35 +1433,37 @@ namespace WoWExportTools
             {
                 try
                 {
-                    var filePath = dialogM2Open.FileName;
-                    using (Stream dataStream = dialogM2Open.OpenFile())
+                    foreach (string filePath in dialogM2Open.FileNames)
                     {
-                        BinaryReader data = new BinaryReader(dataStream);
-                        uint magic = data.ReadUInt32();
-
-                        // Rewind the data source before we pass it to any readers.
-                        dataStream.Seek(0, SeekOrigin.Begin);
-
-                        switch (magic)
+                        using (Stream dataStream = dialogM2Open.OpenFile())
                         {
-                            case (uint)M2Chunks.MD20:
-                            case (uint)M2Chunks.MD21:
-                                M2Reader readerM2 = new M2Reader();
-                                readerM2.LoadM2(dataStream);
+                            BinaryReader data = new BinaryReader(dataStream);
+                            uint magic = data.ReadUInt32();
 
-                                Exporters.OBJ.M2Exporter.ExportM2(readerM2, filePath, null, Path.GetDirectoryName(filePath), true);
-                                break;
+                            // Rewind the data source before we pass it to any readers.
+                            dataStream.Seek(0, SeekOrigin.Begin);
 
-                            case (uint)MDXChunks.MDLX:
-                                MDXReader readerMDX = new MDXReader();
-                                readerMDX.LoadModel(dataStream);
+                            switch (magic)
+                            {
+                                case (uint)M2Chunks.MD20:
+                                case (uint)M2Chunks.MD21:
+                                    M2Reader readerM2 = new M2Reader();
+                                    readerM2.LoadM2(dataStream);
 
-                                string outFile = Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + ".obj");
-                                Exporters.OBJ.MDXExporter.ExportMDX(readerMDX, outFile, null);
-                                break;
+                                    Exporters.OBJ.M2Exporter.ExportM2(readerM2, filePath, null, Path.GetDirectoryName(filePath), true);
+                                    break;
 
-                            default:
-                                throw new Exception("Unknown file format!");
+                                case (uint)MDXChunks.MDLX:
+                                    MDXReader readerMDX = new MDXReader();
+                                    readerMDX.LoadModel(dataStream);
+
+                                    string outFile = Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + ".obj");
+                                    Exporters.OBJ.MDXExporter.ExportMDX(readerMDX, outFile, null);
+                                    break;
+
+                                default:
+                                    throw new Exception("Unknown file format!");
+                            }
                         }
                     }
                 }
@@ -1476,17 +1480,19 @@ namespace WoWExportTools
             {
                 try
                 {
-                    var filePath = dialogBLPOpen.FileName;
-                    using (Stream dataStream = dialogBLPOpen.OpenFile())
+                    foreach (string filePath in dialogBLPOpen.FileNames)
                     {
-                        BLPReader reader = new BLPReader();
-                        reader.LoadBLP(dataStream);
+                        using (Stream dataStream = dialogBLPOpen.OpenFile())
+                        {
+                            BLPReader reader = new BLPReader();
+                            reader.LoadBLP(dataStream);
 
-                        Bitmap bmp = reader.bmp;
-                        if (ignoreTextureAlpha)
-                            bmp = bmp.Clone(new Rectangle(0, 0, bmp.Width, bmp.Height), System.Drawing.Imaging.PixelFormat.Format32bppRgb);
+                            Bitmap bmp = reader.bmp;
+                            if (ignoreTextureAlpha)
+                                bmp = bmp.Clone(new Rectangle(0, 0, bmp.Width, bmp.Height), System.Drawing.Imaging.PixelFormat.Format32bppRgb);
 
-                        bmp.Save(Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + ".png"));
+                            bmp.Save(Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + ".png"));
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/WoWExportTools/MainWindow.xaml.cs
+++ b/WoWExportTools/MainWindow.xaml.cs
@@ -1435,7 +1435,7 @@ namespace WoWExportTools
                 {
                     foreach (string filePath in dialogM2Open.FileNames)
                     {
-                        using (Stream dataStream = dialogM2Open.OpenFile())
+                        using (Stream dataStream = File.OpenRead(filePath))
                         {
                             BinaryReader data = new BinaryReader(dataStream);
                             uint magic = data.ReadUInt32();
@@ -1482,7 +1482,7 @@ namespace WoWExportTools
                 {
                     foreach (string filePath in dialogBLPOpen.FileNames)
                     {
-                        using (Stream dataStream = dialogBLPOpen.OpenFile())
+                        using (Stream dataStream = File.OpenRead(filePath))
                         {
                             BLPReader reader = new BLPReader();
                             reader.LoadBLP(dataStream);


### PR DESCRIPTION
This PR implements the following changes:
- Flip exported MDX models on Y axis to match expected results.
- Materials are now now mapped and exported in an MTL.
- Fixed a small technical bug with incorrectly parsed UVBS blocks.
- Local exporters can now operate on multiple files at once.

This PR relies on https://github.com/Marlamin/WoWFormatLib/pull/5