### PR TITLE
Adjusting M2 and WMO to be more compatible with OBJ spec, better 3DS …

### DIFF
--- a/WoWExportTools/Exporters/OBJ/M2Exporter.cs
+++ b/WoWExportTools/Exporters/OBJ/M2Exporter.cs
@@ -113,10 +113,18 @@ namespace WoWExportTools.Exporters.OBJ
             objWriter.WriteLine("# Written by Marlamin's WoW Export Tools. Source file: " + fileName);
             objWriter.WriteLine("mtllib " + Path.GetFileName(mtlFilePath));
 
+            //Adjusted according to the WaveFront Object (.obj) File Format spec
+            //https://people.cs.clemson.edu/~dhouse/courses/405/docs/brief-obj-file-format.html
             foreach (var vertex in vertices)
             {
                 objWriter.WriteLine("v " + vertex.Position.X + " " + vertex.Position.Y + " " + vertex.Position.Z);
+            }
+            foreach (var vertex in vertices)
+            {
                 objWriter.WriteLine("vt " + vertex.TexCoord.X + " " + (vertex.TexCoord.Y - 1) * -1);
+            }
+            foreach (var vertex in vertices)
+            {
                 objWriter.WriteLine("vn " + (-vertex.Normal.X).ToString("F12") + " " + vertex.Normal.Y.ToString("F12") + " " + vertex.Normal.Z.ToString("F12"));
             }
 

--- a/WoWExportTools/Exporters/OBJ/WMOExporter.cs
+++ b/WoWExportTools/Exporters/OBJ/WMOExporter.cs
@@ -389,22 +389,31 @@ namespace WoWExportTools.Exporters.OBJ
 
                 Console.WriteLine("Writing " + group.name);
 
+                //Adjusted according to the WaveFront Object (.obj) File Format spec
+                //https://people.cs.clemson.edu/~dhouse/courses/405/docs/brief-obj-file-format.html
                 foreach (var vertex in group.vertices)
                 {
                     objWriter.WriteLine("v " + vertex.Position.X + " " + vertex.Position.Y + " " + vertex.Position.Z);
-                    objWriter.WriteLine("vt " + vertex.TexCoord.X + " " + (vertex.TexCoord.Y - 1) * -1);
+                }
+                foreach (var vertex in group.vertices)
+                {
+                    objWriter.WriteLine("vt " + vertex.TexCoord.X + " " + (vertex.TexCoord.Y - 1) * -1 + " 0.0000");
+                }
+                foreach (var vertex in group.vertices)
+                {
                     objWriter.WriteLine("vn " + (-vertex.Normal.X).ToString("F12") + " " + vertex.Normal.Y.ToString("F12") + " " + vertex.Normal.Z.ToString("F12"));
                 }
 
-                var indices = group.indices;
 
+                var indices = group.indices;
                 for (int rbi = 0; rbi < group.renderBatches.Count(); rbi++)
                 {
                     var renderbatch = group.renderBatches[rbi];
                     var i = renderbatch.firstFace;
                     if (renderbatch.numFaces > 0)
                     {
-                        objWriter.WriteLine("g " + group.name + rbi);
+                        objWriter.WriteLine("o " + group.name + rbi);
+                        objWriter.WriteLine("g " + group.name + rbi); //3DS Max's OBJ importer fails with invalid normal index without groups being defined
                         objWriter.WriteLine("usemtl " + materials[renderbatch.materialID].filename);
                         objWriter.WriteLine("s 1");
                         while (i < (renderbatch.firstFace + renderbatch.numFaces))


### PR DESCRIPTION
Fixing issue #75 that caused 3DS Max to error out on import and adjusting the [file formatting to be within the spec](http://www.fileformat.info/format/wavefrontobj/egff.htm). More sensitive OBJ importers should now be able to import the exported models error free.
3DS Max also requires a group name to be defined or it will error out.
This unfortunately doesn't fix issues with 3DS Max 2018, as the [OBJ importer itself is broken and Autodesk acknowledged the problem without providing a fix.](https://knowledge.autodesk.com/support/3ds-max/troubleshooting/caas/sfdcarticles/sfdcarticles/Error-Invalid-Texture-Index-when-importing-certain-obj-files-into-3ds-Max-2018.html)
Max 2018 users will encounter "Invalid texture index" error that can be only fixed by selecting "Import as single mesh" or running it through an external application to convert the model.